### PR TITLE
Allow OS assign a free port number

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : ''
+}

--- a/TCPServer-Tests/TCPServerTestCase.class.st
+++ b/TCPServer-Tests/TCPServerTestCase.class.st
@@ -45,7 +45,7 @@ TCPServerTestCase >> setUp [
 	
 	clientSockets := OrderedCollection new.
 	
-	server := self serverClass on: 40422
+	server := self serverClass new
 ]
 
 { #category : #running }

--- a/TCPServer-Tests/TCPServerTests.class.st
+++ b/TCPServer-Tests/TCPServerTests.class.st
@@ -65,6 +65,23 @@ TCPServerTests >> testHasProcessingPriorityByDefault [
 ]
 
 { #category : #tests }
+TCPServerTests >> testHasSelfAssignedZeroPortByDefault [
+
+	self assert: server port equals: 0
+]
+
+{ #category : #tests }
+TCPServerTests >> testStartingServerOnGivenPortShouldUseIt [
+
+	| requiredPort |
+	requiredPort := 40522 + 32 atRandom.
+	server port: requiredPort.
+	server start.
+
+	self assert: server port equals: requiredPort
+]
+
+{ #category : #tests }
 TCPServerTests >> testStartingServerOnPortWhichIsAlreadyInUse [
 
 	| newServer |
@@ -85,6 +102,16 @@ TCPServerTests >> testStartingServerShouldAddItToRunningList [
 	server start.
 	
 	self assert: (TCPServer runningServers includes: server)
+]
+
+{ #category : #tests }
+TCPServerTests >> testStartingServerShouldAssignRetrievedPort [
+
+	self assert: server port equals: 0.
+	
+	server start.
+
+	self assert: server port > 0
 ]
 
 { #category : #tests }

--- a/TCPServer/TCPPharoNetworkLibrary.class.st
+++ b/TCPServer/TCPPharoNetworkLibrary.class.st
@@ -26,7 +26,7 @@ TCPPharoNetworkLibrary class >> newListenerSocketOn: port [
 
 	socket isValid
 		ifFalse: [ self error: 'Cannot create socket on port ' , port asString ].
-	socket localPort = port ifFalse: [ 
+	port ~= 0 & (socket localPort ~= port) ifTrue: [ 
 		socket close; destroy.
 		self error: 'Port ' , port asString, ' is busy. Try use another port'].	
 	

--- a/TCPServer/TCPServer.class.st
+++ b/TCPServer/TCPServer.class.st
@@ -1,11 +1,37 @@
 "
 I am most primitive TCP server. I implement classic incoming connections loop. My subclasses should implement #processNewConnection: .
 
-I am created by #on: message with port number as argument.  Then you should call #start  to run listener socket and incoming connections loop.
-I have list of running servers on class side.
-#stop message will close listener socket and terminate incoming connections process. 
+To start a server simply create an instance and ask it to #start:
 
-I delegate sockets creation to TCPNetworkLibrary implementation. It provides simple hook to set up different socket libraries (like Ocean).
+	server := TCPServerSubclass new.
+	server start.
+
+It will run listener socket and incoming connections loop.
+
+By default I allow OS to assign free port for me (using zero port number):
+
+	server := TCPServerSubclass new.
+	server port. ""==> 0""
+	server start.
+	server port > 0 ""==> true""
+
+But users can specify concrete port using #on: message: 
+
+	server := TCPServerSubclass on: 40422
+
+If given port is busy the #start message will signal an error.
+		
+To stop the server use #stop message: 
+	
+	server stop.
+	
+It will close listener socket and terminate incoming connections loop. 
+
+I maintain the list of all running servers on my class side variable #RunningServers.
+
+Implementation details
+
+I delegate sockets creation to TCPNetworkLibrary implementation. It provides simple hook to set up different socket libraries (like Ocean) and simplifies testing.
 
 Public API and Key Messages
 
@@ -19,8 +45,8 @@ Internal Representation and Key Implementation Points.
 	incomingConnectionsProcess:		<Process>
 	listenerSocket:		<Socket>
 	networkLibrary:		<TCPNetworkLibrary>
-	port:		<Number>
-	processingPriority:		<Number>
+	port:		<SmallInteger>
+	processingPriority:		<SmallInteger>
 
 "
 Class {
@@ -38,7 +64,7 @@ Class {
 		'AlwaysRestart',
 		'RunningServers'
 	],
-	#category : 'TCPServer'
+	#category : #TCPServer
 }
 
 { #category : #accessing }
@@ -150,6 +176,7 @@ TCPServer >> incomingConnectionsProcess: anObject [
 TCPServer >> initialize [ 
 	super initialize.
 	
+	port := 0. "zero specifies self assigned port for server (assigned by OS)"
 	networkLibrary := TCPPharoNetworkLibrary.
 	processingPriority := Processor highIOPriority.
 	listeningTimeout := 10 seconds
@@ -158,7 +185,8 @@ TCPServer >> initialize [
 { #category : #private }
 TCPServer >> initializeListenerSocket [
 
-	listenerSocket := networkLibrary newListenerSocketOn: port
+	listenerSocket := networkLibrary newListenerSocketOn: port.
+	port := listenerSocket port
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Allow OS assign a free port using zero port number as default.
Now servers can be simply created using #new without port number